### PR TITLE
use \s+ instead of single space for job status text split delimiter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lsf/LSF.java
+++ b/src/main/java/org/jenkinsci/plugins/lsf/LSF.java
@@ -95,7 +95,7 @@ public class LSF extends BatchSystem {
         BufferedReader fileReader = new BufferedReader(
                 new FileReader(masterWorkingDirectory + COMMUNICATION_FILE));
         fileReader.readLine();
-        return fileReader.readLine().trim().split(" ")[2];
+        return fileReader.readLine().trim().split("\\s+")[2];
     }
 
     @Override


### PR DESCRIPTION
How did this work with just split(" ")?  bjobs output example text on IBM documentation shows multiple spaces as delimiter.